### PR TITLE
Add memory-hard scrypt mode and uv-first workflow docs

### DIFF
--- a/.replit
+++ b/.replit
@@ -24,7 +24,7 @@ author = "agent"
 
 [[workflows.workflow.tasks]]
 task = "shell.exec"
-args = "python main.py --help"
+args = "uv run python main.py --help"
 
 [workflows.workflow.metadata]
 outputType = "console"

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Encrypt plaintext with a key-derivation puzzle so decryption takes deliberate
 work. The tool supports both:
 
-- `sha256-chain`: sequential time-lock hashing (CPU-bound)
+- `sha256`: sequential time-lock hashing (CPU-bound)
 - `scrypt`: memory-hard KDF (more resistant to GPU/ASIC acceleration)
 
 ## How it works
 
-### 1) `sha256-chain` (time-lock mode)
+### 1) `sha256` (time-lock mode)
 
 Encryption runs a sequential SHA-256 chain for the requested wall-clock
 duration and stores the resulting `work_units`. Decryption reproduces exactly
@@ -47,7 +47,7 @@ uv sync
 uv run python main.py generate-password --length 16
 ```
 
-### Encrypt with default time-lock (`sha256-chain`)
+### Encrypt with default time-lock (`sha256`)
 
 ```bash
 uv run python main.py encrypt 'MyS3cr3t!' --time-in-seconds 10 --output-file locked.json
@@ -81,11 +81,11 @@ uv run python main.py decrypt locked.json --show-progress
 
 ## Output JSON formats
 
-### `sha256-chain`
+### `sha256`
 
 ```json
 {
-  "algorithm": "sha256-chain",
+  "algorithm": "sha256",
   "seed": "example-seed",
   "work_units": 12345000,
   "encrypted": "..."
@@ -121,7 +121,7 @@ uv run pytest tests -v
 ```text
 .
 ├── main.py          # CLI (Typer): generate-password, encrypt, decrypt
-├── puzzle.py        # Key-derivation + Fernet encrypt/decrypt (sha256-chain, scrypt)
+├── puzzle.py        # Key-derivation + Fernet encrypt/decrypt (sha256, scrypt)
 ├── randpass.py      # Cryptographically secure password generator (secrets module)
 ├── progress.py      # tqdm progress-bar helper
 ├── tests/           # pytest suite

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ work. The tool supports both:
 ### 1) `sha256-chain` (time-lock mode)
 
 Encryption runs a sequential SHA-256 chain for the requested wall-clock
-duration and stores the iteration count. Decryption reproduces exactly that
-many rounds to rebuild the key.
+duration and stores the resulting `work_units`. Decryption reproduces exactly
+that many rounds to rebuild the key.
 
-### 2) `scrypt` (memory-hard mode)
+### 2) `scrypt` (memory-hard time-lock mode)
 
-Encryption derives a key using `scrypt(seed, salt, n, r, p)` and stores the
-scrypt parameters + salt in output JSON. Decryption replays the same scrypt
-derivation.
+Encryption repeatedly applies `scrypt(seed, salt, n, r, p)` for the requested
+time budget and stores `work_units` plus the scrypt parameters/salt in output
+JSON. Decryption replays exactly the same number of sequential rounds.
 
 Both modes then use a [Fernet](https://cryptography.io/en/latest/fernet/) key
 to encrypt/decrypt payload data.
@@ -58,6 +58,7 @@ uv run python main.py encrypt 'MyS3cr3t!' --time-in-seconds 10 --output-file loc
 ```bash
 uv run python main.py encrypt 'MyS3cr3t!' \
   --algorithm scrypt \
+  --time-in-seconds 10 \
   --scrypt-n 16384 \
   --scrypt-r 8 \
   --scrypt-p 1 \
@@ -71,6 +72,13 @@ uv run python main.py decrypt locked.json
 uv run python main.py decrypt locked-scrypt.json
 ```
 
+### Show progress bar (disabled by default)
+
+```bash
+uv run python main.py encrypt 'MyS3cr3t!' --time-in-seconds 10 --show-progress
+uv run python main.py decrypt locked.json --show-progress
+```
+
 ## Output JSON formats
 
 ### `sha256-chain`
@@ -79,7 +87,7 @@ uv run python main.py decrypt locked-scrypt.json
 {
   "algorithm": "sha256-chain",
   "seed": "example-seed",
-  "iters": 12345000,
+  "work_units": 12345000,
   "encrypted": "..."
 }
 ```
@@ -90,6 +98,7 @@ uv run python main.py decrypt locked-scrypt.json
 {
   "algorithm": "scrypt",
   "seed": "example-seed",
+  "work_units": 24,
   "scrypt": {
     "n": 16384,
     "r": 8,

--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
 # passobfuscator
 
-Encrypt plain text with a time-lock so that decryption requires a configurable
-amount of CPU time. The original motivation was to keep a gaming account password
-inaccessible during self-imposed breaks — without fully losing access.
+Encrypt plaintext with a key-derivation puzzle so decryption takes deliberate
+work. The tool supports both:
+
+- `sha256-chain`: sequential time-lock hashing (CPU-bound)
+- `scrypt`: memory-hard KDF (more resistant to GPU/ASIC acceleration)
 
 ## How it works
 
-During encryption the tool runs a sequential SHA-256 hash chain for the
-requested number of seconds and counts the iterations it managed to complete.
-The final hash is used as a [Fernet](https://cryptography.io/en/latest/fernet/)
-symmetric key to encrypt the plaintext. The iteration count is stored alongside
-the ciphertext.
+### 1) `sha256-chain` (time-lock mode)
 
-Decryption replays _exactly_ the same number of hash rounds (starting from the
-same seed) to reconstruct the key. Because each round depends on the previous
-one, the work cannot be parallelised — decryption therefore takes approximately
-the same wall-clock time as encryption did on the same hardware.
+Encryption runs a sequential SHA-256 chain for the requested wall-clock
+duration and stores the iteration count. Decryption reproduces exactly that
+many rounds to rebuild the key.
+
+### 2) `scrypt` (memory-hard mode)
+
+Encryption derives a key using `scrypt(seed, salt, n, r, p)` and stores the
+scrypt parameters + salt in output JSON. Decryption replays the same scrypt
+derivation.
+
+Both modes then use a [Fernet](https://cryptography.io/en/latest/fernet/) key
+to encrypt/decrypt payload data.
 
 ## Requirements
 
-- Python ≥ 3.11
-- [uv](https://docs.astral.sh/uv/) (recommended) **or** pip
+- Python >= 3.11
+- [uv](https://docs.astral.sh/uv/) (required workflow for this repo)
 
 ## Installation
 
@@ -29,76 +35,87 @@ the same wall-clock time as encryption did on the same hardware.
 git clone https://github.com/nietoga/passobsfucator.git
 cd passobsfucator
 
-# Install with uv (creates an isolated virtual environment automatically)
+# Install dependencies from pyproject.toml/uv.lock
 uv sync
-
-# Or with pip
-pip install .
 ```
 
-## Usage
+## Usage (always via uv)
 
 ### Generate a random password
 
 ```bash
-python main.py generate-password --length 16
-# or via uv:
 uv run python main.py generate-password --length 16
 ```
 
-### Encrypt a value
+### Encrypt with default time-lock (`sha256-chain`)
 
 ```bash
-# Default: 1 hour of decryption time
-python main.py encrypt 'MyS3cr3t!' --time-in-seconds 3600 --output-file encrypted.json
-
-# Quick demo (10-second lock)
-python main.py encrypt 'MyS3cr3t!' --time-in-seconds 10 --output-file encrypted.json
+uv run python main.py encrypt 'MyS3cr3t!' --time-in-seconds 10 --output-file locked.json
 ```
 
-> **Note**: encryption takes the same amount of CPU time as decryption will.
-
-### Decrypt a value
+### Encrypt with memory-hard `scrypt`
 
 ```bash
-python main.py decrypt encrypted.json
+uv run python main.py encrypt 'MyS3cr3t!' \
+  --algorithm scrypt \
+  --scrypt-n 16384 \
+  --scrypt-r 8 \
+  --scrypt-p 1 \
+  --output-file locked-scrypt.json
 ```
 
-### End-to-end demo
+### Decrypt
 
 ```bash
-# 1. Generate a password and encrypt it with a 10-second lock
-python main.py generate-password --length 16 > raw.txt
-python main.py encrypt "$(cat raw.txt)" --time-in-seconds 10 --output-file locked.json
-rm raw.txt           # discard the plaintext
+uv run python main.py decrypt locked.json
+uv run python main.py decrypt locked-scrypt.json
+```
 
-# 2. (wait however long you like)
+## Output JSON formats
 
-# 3. Recover the password — takes ~10 s of CPU time
-python main.py decrypt locked.json
+### `sha256-chain`
+
+```json
+{
+  "algorithm": "sha256-chain",
+  "seed": "example-seed",
+  "iters": 12345000,
+  "encrypted": "..."
+}
+```
+
+### `scrypt`
+
+```json
+{
+  "algorithm": "scrypt",
+  "seed": "example-seed",
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 1,
+    "salt": "base64-url-safe-salt"
+  },
+  "encrypted": "..."
+}
 ```
 
 ## Development
 
 ```bash
-# Install all dependencies (including dev extras)
 uv sync
-
-# Run tests
-uv run pytest
-# or
-python -m pytest tests/ -v
+uv run pytest tests -v
 ```
 
 ## Project layout
 
-```
+```text
 .
-├── main.py          # CLI (typer): generate-password, encrypt, decrypt
-├── puzzle.py        # Time-lock core: hash-chain key derivation + Fernet encrypt/decrypt
+├── main.py          # CLI (Typer): generate-password, encrypt, decrypt
+├── puzzle.py        # Key-derivation + Fernet encrypt/decrypt (sha256-chain, scrypt)
 ├── randpass.py      # Cryptographically secure password generator (secrets module)
 ├── progress.py      # tqdm progress-bar helper
-├── tests/           # pytest test suite
-├── pyproject.toml   # Project metadata & dependencies (uv / pip)
-└── uv.lock          # Reproducible dependency lock file
+├── tests/           # pytest suite
+├── pyproject.toml   # Project metadata + dependencies
+└── uv.lock          # Locked dependency set for uv
 ```

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 """CLI entry-point for the time-lock password obfuscation tool."""
 
+import base64
+import binascii
 import json
 from datetime import timedelta
 from pathlib import Path
@@ -30,6 +32,15 @@ def generate_password(
 @app.command()
 def encrypt(
     value: Annotated[str, typer.Argument(help="Plaintext value to encrypt.")],
+    algorithm: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Key-derivation algorithm: 'sha256-chain' (time-lock) "
+                "or 'scrypt' (memory-hard, more resistant to GPU attacks)."
+            )
+        ),
+    ] = puzzle.ALGORITHM_SHA256_CHAIN,
     time_in_seconds: Annotated[
         int, typer.Option(help="CPU seconds required to decrypt.")
     ] = 3600,
@@ -41,6 +52,20 @@ def encrypt(
         Optional[Path],
         typer.Option(help="Write JSON output here instead of stdout."),
     ] = None,
+    scrypt_n: Annotated[
+        int,
+        typer.Option(
+            help="scrypt N cost parameter (power of two; only for --algorithm scrypt)."
+        ),
+    ] = 2**14,
+    scrypt_r: Annotated[
+        int,
+        typer.Option(help="scrypt r block-size parameter (only for scrypt)."),
+    ] = 8,
+    scrypt_p: Annotated[
+        int,
+        typer.Option(help="scrypt p parallelization parameter (only for scrypt)."),
+    ] = 1,
 ) -> None:
     """Encrypt VALUE so that decryption requires ~TIME_IN_SECONDS of CPU time.
 
@@ -48,18 +73,52 @@ def encrypt(
     The exact decryption time may vary slightly depending on the machine's speed.
     """
     chosen_seed = seed or randpass.generate(10)
-    delta = timedelta(seconds=time_in_seconds)
 
-    with ProgressBar() as progress_bar:
-        _, iters, encrypted = puzzle.encrypt(
-            chosen_seed.encode(), delta, value.encode(), progress_bar.set_progress
+    if algorithm == puzzle.ALGORITHM_SHA256_CHAIN:
+        delta = timedelta(seconds=time_in_seconds)
+        with ProgressBar() as progress_bar:
+            _, iters, encrypted = puzzle.encrypt(
+                chosen_seed.encode(), delta, value.encode(), progress_bar.set_progress
+            )
+
+        output = {
+            "algorithm": puzzle.ALGORITHM_SHA256_CHAIN,
+            "seed": chosen_seed,
+            "iters": iters,
+            "encrypted": encrypted.decode(),
+        }
+    elif algorithm == puzzle.ALGORITHM_SCRYPT:
+        try:
+            with ProgressBar() as progress_bar:
+                _, salt, encrypted = puzzle.encrypt_scrypt(
+                    chosen_seed.encode(),
+                    value.encode(),
+                    n=scrypt_n,
+                    r=scrypt_r,
+                    p=scrypt_p,
+                    progress_callback=progress_bar.set_progress,
+                )
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+        output = {
+            "algorithm": puzzle.ALGORITHM_SCRYPT,
+            "seed": chosen_seed,
+            "scrypt": {
+                "n": scrypt_n,
+                "r": scrypt_r,
+                "p": scrypt_p,
+                "salt": base64.urlsafe_b64encode(salt).decode(),
+            },
+            "encrypted": encrypted.decode(),
+        }
+    else:
+        typer.echo(
+            "Error: Unsupported algorithm. Use 'sha256-chain' or 'scrypt'.",
+            err=True,
         )
-
-    output = {
-        "seed": chosen_seed,
-        "iters": iters,
-        "encrypted": encrypted.decode(),
-    }
+        raise typer.Exit(code=1)
 
     if output_file is None:
         typer.echo(json.dumps(output, indent=4))
@@ -84,19 +143,50 @@ def decrypt(
         typer.echo(f"Error reading {input_file}: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    seed: str = payload["seed"]
-    iters: int = payload["iters"]
-    encrypted: str = payload["encrypted"]
+    algorithm = payload.get("algorithm", puzzle.ALGORITHM_SHA256_CHAIN)
 
-    with ProgressBar() as progress_bar:
-        _, decrypted = puzzle.decrypt(
-            seed.encode(), iters, encrypted.encode(), progress_bar.set_progress
-        )
+    try:
+        seed: str = payload["seed"]
+        encrypted: str = payload["encrypted"]
+    except KeyError as exc:
+        typer.echo(f"Error reading {input_file}: missing required field {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
-    output = {
-        "seed": seed,
-        "decrypted": decrypted.decode(),
-    }
+    try:
+        if algorithm == puzzle.ALGORITHM_SHA256_CHAIN:
+            iters = int(payload["iters"])
+            with ProgressBar() as progress_bar:
+                _, decrypted = puzzle.decrypt(
+                    seed.encode(), iters, encrypted.encode(), progress_bar.set_progress
+                )
+        elif algorithm == puzzle.ALGORITHM_SCRYPT:
+            scrypt_params = payload["scrypt"]
+            n = int(scrypt_params["n"])
+            r = int(scrypt_params["r"])
+            p = int(scrypt_params["p"])
+            salt = base64.urlsafe_b64decode(scrypt_params["salt"].encode())
+            with ProgressBar() as progress_bar:
+                _, decrypted = puzzle.decrypt_scrypt(
+                    seed.encode(),
+                    encrypted.encode(),
+                    salt=salt,
+                    n=n,
+                    r=r,
+                    p=p,
+                    progress_callback=progress_bar.set_progress,
+                )
+        else:
+            typer.echo(
+                "Error reading input file: unsupported algorithm. "
+                "Use 'sha256-chain' or 'scrypt'.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+    except (KeyError, TypeError, ValueError, binascii.Error) as exc:
+        typer.echo(f"Error reading {input_file}: malformed encryption payload ({exc})", err=True)
+        raise typer.Exit(code=1) from exc
+
+    output = {"algorithm": algorithm, "seed": seed, "decrypted": decrypted.decode()}
 
     if output_file is None:
         typer.echo(json.dumps(output, indent=4))

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import base64
 import binascii
 import json
+from contextlib import nullcontext
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Optional
@@ -14,6 +15,14 @@ import randpass
 from progress import ProgressBar
 
 app = typer.Typer(help="Password obfuscation utility using time-lock encryption.")
+
+
+def _progress_context(show_progress: bool) -> tuple[object, puzzle.ProgressCallback]:
+    """Return a context manager and callback based on progress-bar preference."""
+    if show_progress:
+        progress_bar = ProgressBar()
+        return progress_bar, progress_bar.set_progress
+    return nullcontext(), None
 
 
 @app.command()
@@ -66,6 +75,13 @@ def encrypt(
         int,
         typer.Option(help="scrypt p parallelization parameter (only for scrypt)."),
     ] = 1,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--show-progress",
+            help="Show tqdm progress bar during key derivation.",
+        ),
+    ] = False,
 ) -> None:
     """Encrypt VALUE so that decryption requires ~TIME_IN_SECONDS of CPU time.
 
@@ -73,52 +89,36 @@ def encrypt(
     The exact decryption time may vary slightly depending on the machine's speed.
     """
     chosen_seed = seed or randpass.generate(10)
+    delta = timedelta(seconds=time_in_seconds)
 
-    if algorithm == puzzle.ALGORITHM_SHA256_CHAIN:
-        delta = timedelta(seconds=time_in_seconds)
-        with ProgressBar() as progress_bar:
-            _, iters, encrypted = puzzle.encrypt(
-                chosen_seed.encode(), delta, value.encode(), progress_bar.set_progress
-            )
-
-        output = {
-            "algorithm": puzzle.ALGORITHM_SHA256_CHAIN,
-            "seed": chosen_seed,
-            "iters": iters,
-            "encrypted": encrypted.decode(),
-        }
-    elif algorithm == puzzle.ALGORITHM_SCRYPT:
-        try:
-            with ProgressBar() as progress_bar:
-                _, salt, encrypted = puzzle.encrypt_scrypt(
-                    chosen_seed.encode(),
-                    value.encode(),
-                    n=scrypt_n,
-                    r=scrypt_r,
-                    p=scrypt_p,
-                    progress_callback=progress_bar.set_progress,
-                )
-        except ValueError as exc:
-            typer.echo(f"Error: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
-
-        output = {
-            "algorithm": puzzle.ALGORITHM_SCRYPT,
-            "seed": chosen_seed,
-            "scrypt": {
-                "n": scrypt_n,
-                "r": scrypt_r,
-                "p": scrypt_p,
-                "salt": base64.urlsafe_b64encode(salt).decode(),
-            },
-            "encrypted": encrypted.decode(),
-        }
-    else:
-        typer.echo(
-            "Error: Unsupported algorithm. Use 'sha256-chain' or 'scrypt'.",
-            err=True,
+    try:
+        strategy = puzzle.build_strategy(
+            algorithm,
+            scrypt_n=scrypt_n,
+            scrypt_r=scrypt_r,
+            scrypt_p=scrypt_p,
         )
-        raise typer.Exit(code=1)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    progress_context, progress_callback = _progress_context(show_progress)
+    with progress_context:
+        _, work_units, encrypted, strategy_payload = puzzle.encrypt_with_strategy(
+            chosen_seed.encode(),
+            delta,
+            value.encode(),
+            strategy=strategy,
+            progress_callback=progress_callback,
+        )
+
+    output = {
+        "algorithm": strategy.name,
+        "seed": chosen_seed,
+        "work_units": work_units,
+        "encrypted": encrypted.decode(),
+        **strategy_payload,
+    }
 
     if output_file is None:
         typer.echo(json.dumps(output, indent=4))
@@ -135,6 +135,13 @@ def decrypt(
         Optional[Path],
         typer.Option(help="Write JSON output here instead of stdout."),
     ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--show-progress",
+            help="Show tqdm progress bar during key derivation replay.",
+        ),
+    ] = False,
 ) -> None:
     """Decrypt a value previously encrypted with the encrypt command."""
     try:
@@ -153,35 +160,29 @@ def decrypt(
         raise typer.Exit(code=1) from exc
 
     try:
-        if algorithm == puzzle.ALGORITHM_SHA256_CHAIN:
-            iters = int(payload["iters"])
-            with ProgressBar() as progress_bar:
-                _, decrypted = puzzle.decrypt(
-                    seed.encode(), iters, encrypted.encode(), progress_bar.set_progress
-                )
-        elif algorithm == puzzle.ALGORITHM_SCRYPT:
+        # Backward compatibility: old payloads used "iters", new payloads use "work_units".
+        work_units = int(payload["work_units"] if "work_units" in payload else payload["iters"])
+
+        strategy_kwargs: dict[str, int | bytes | None] = {}
+        if algorithm == puzzle.ALGORITHM_SCRYPT:
             scrypt_params = payload["scrypt"]
-            n = int(scrypt_params["n"])
-            r = int(scrypt_params["r"])
-            p = int(scrypt_params["p"])
-            salt = base64.urlsafe_b64decode(scrypt_params["salt"].encode())
-            with ProgressBar() as progress_bar:
-                _, decrypted = puzzle.decrypt_scrypt(
-                    seed.encode(),
-                    encrypted.encode(),
-                    salt=salt,
-                    n=n,
-                    r=r,
-                    p=p,
-                    progress_callback=progress_bar.set_progress,
-                )
-        else:
-            typer.echo(
-                "Error reading input file: unsupported algorithm. "
-                "Use 'sha256-chain' or 'scrypt'.",
-                err=True,
+            strategy_kwargs = {
+                "scrypt_n": int(scrypt_params["n"]),
+                "scrypt_r": int(scrypt_params["r"]),
+                "scrypt_p": int(scrypt_params["p"]),
+                "scrypt_salt": base64.urlsafe_b64decode(scrypt_params["salt"].encode()),
+            }
+
+        strategy = puzzle.build_strategy(algorithm, **strategy_kwargs)
+        progress_context, progress_callback = _progress_context(show_progress)
+        with progress_context:
+            _, decrypted = puzzle.decrypt_with_strategy(
+                seed.encode(),
+                work_units,
+                encrypted.encode(),
+                strategy=strategy,
+                progress_callback=progress_callback,
             )
-            raise typer.Exit(code=1)
     except (KeyError, TypeError, ValueError, binascii.Error) as exc:
         typer.echo(f"Error reading {input_file}: malformed encryption payload ({exc})", err=True)
         raise typer.Exit(code=1) from exc

--- a/main.py
+++ b/main.py
@@ -45,11 +45,11 @@ def encrypt(
         str,
         typer.Option(
             help=(
-                "Key-derivation algorithm: 'sha256-chain' (time-lock) "
+                "Key-derivation algorithm: 'sha256' (time-lock) "
                 "or 'scrypt' (memory-hard, more resistant to GPU attacks)."
             )
         ),
-    ] = puzzle.ALGORITHM_SHA256_CHAIN,
+    ] = puzzle.ALGORITHM_SHA256,
     time_in_seconds: Annotated[
         int, typer.Option(help="CPU seconds required to decrypt.")
     ] = 3600,
@@ -150,7 +150,10 @@ def decrypt(
         typer.echo(f"Error reading {input_file}: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    algorithm = payload.get("algorithm", puzzle.ALGORITHM_SHA256_CHAIN)
+    algorithm = payload.get("algorithm", puzzle.ALGORITHM_SHA256)
+    if algorithm == puzzle.ALGORITHM_SHA256_CHAIN:
+        # Backward compatibility with older payloads.
+        algorithm = puzzle.ALGORITHM_SHA256
 
     try:
         seed: str = payload["seed"]

--- a/main.py
+++ b/main.py
@@ -164,7 +164,10 @@ def decrypt(
 
     try:
         # Backward compatibility: old payloads used "iters", new payloads use "work_units".
-        work_units = int(payload["work_units"] if "work_units" in payload else payload["iters"])
+        raw_work_units = payload.get("work_units")
+        if raw_work_units is None:
+            raw_work_units = payload["iters"]
+        work_units = int(raw_work_units)
 
         strategy_kwargs: dict[str, int | bytes | None] = {}
         if algorithm == puzzle.ALGORITHM_SCRYPT:

--- a/puzzle.py
+++ b/puzzle.py
@@ -1,9 +1,7 @@
-"""Time-lock puzzle via sequential SHA-256 proof-of-work.
-
-Reference: https://asecuritysite.com/encryption/pow
-"""
+"""Time-lock key-derivation strategies used for encryption/decryption."""
 
 import base64
+from abc import ABC, abstractmethod
 from datetime import timedelta
 from hashlib import scrypt, sha256
 from secrets import token_bytes
@@ -15,18 +13,23 @@ from cryptography.fernet import Fernet
 ALGORITHM_SHA256_CHAIN = "sha256-chain"
 ALGORITHM_SCRYPT = "scrypt"
 
+ProgressCallback = Callable[[int], None] | None
+
 # How often to sample wall-clock time and fire progress callbacks in the
-# tight hashing loop. Checking time() every iteration is measurably slow;
-# checking every TICK_INTERVAL iterations keeps overhead negligible.
+# SHA-256 tight loop. Checking time() every iteration is measurably slow.
 _TICK_INTERVAL = 5_000
 
 
-def _hash_chain(seed: bytes, count: int) -> bytes:
-    """Run *count* sequential SHA-256 hashes starting from *seed*."""
-    h = sha256(seed).digest()
-    for _ in range(count):
-        h = sha256(h).digest()
-    return h
+def _emit_progress(progress_callback: ProgressCallback, value: int) -> None:
+    """Emit clamped progress updates when a callback exists."""
+    if progress_callback:
+        progress_callback(max(0, min(value, 100)))
+
+
+def _validate_work_units(work_units: int) -> None:
+    """Validate replayable work units."""
+    if work_units < 1:
+        raise ValueError("work_units must be >= 1")
 
 
 def _validate_scrypt_params(n: int, r: int, p: int) -> None:
@@ -39,171 +42,279 @@ def _validate_scrypt_params(n: int, r: int, p: int) -> None:
         raise ValueError("scrypt p must be >= 1")
 
 
-def generate_scrypt_key(seed: bytes, salt: bytes, n: int, r: int, p: int) -> bytes:
-    """Derive a Fernet-compatible key using scrypt (memory-hard)."""
-    _validate_scrypt_params(n, r, p)
-    key = scrypt(seed, salt=salt, n=n, r=r, p=p, dklen=32)
-    return base64.urlsafe_b64encode(key)
+class TimeLockStrategy(ABC):
+    """Base strategy for time-lock key derivation."""
+
+    name: str
+
+    @abstractmethod
+    def derive_by_time(
+        self,
+        seed: bytes,
+        delta: timedelta,
+        progress_callback: ProgressCallback = None,
+    ) -> tuple[bytes, int]:
+        """Derive key for approximately *delta* seconds and return key + work units."""
+
+    @abstractmethod
+    def derive_by_work(
+        self,
+        seed: bytes,
+        work_units: int,
+        progress_callback: ProgressCallback = None,
+    ) -> bytes:
+        """Reproduce key by replaying exactly *work_units* operations."""
+
+    def extra_payload(self) -> dict:
+        """Return algorithm-specific metadata for encrypted JSON payloads."""
+        return {}
+
+
+class Sha256ChainStrategy(TimeLockStrategy):
+    """Sequential SHA-256 chain strategy."""
+
+    name = ALGORITHM_SHA256_CHAIN
+
+    def derive_by_time(
+        self,
+        seed: bytes,
+        delta: timedelta,
+        progress_callback: ProgressCallback = None,
+    ) -> tuple[bytes, int]:
+        duration = delta.total_seconds()
+        start = monotonic()
+        end = start + duration
+
+        h = sha256(seed).digest()
+        iters = 0
+        last_progress = -1
+        _emit_progress(progress_callback, 0)
+
+        while True:
+            for _ in range(_TICK_INTERVAL):
+                h = sha256(h).digest()
+            iters += _TICK_INTERVAL
+
+            now = monotonic()
+            if now >= end:
+                break
+
+            if progress_callback:
+                progress = min(int((now - start) * 100 / duration), 99)
+                if progress != last_progress:
+                    last_progress = progress
+                    progress_callback(progress)
+
+        _emit_progress(progress_callback, 100)
+        return base64.urlsafe_b64encode(h), iters
+
+    def derive_by_work(
+        self,
+        seed: bytes,
+        work_units: int,
+        progress_callback: ProgressCallback = None,
+    ) -> bytes:
+        _validate_work_units(work_units)
+        if work_units < 1:
+            raise ValueError("work_units must be >= 1")
+
+        h = sha256(seed).digest()
+        last_progress = -1
+        _emit_progress(progress_callback, 0)
+
+        for i in range(0, work_units, _TICK_INTERVAL):
+            batch = min(_TICK_INTERVAL, work_units - i)
+            for _ in range(batch):
+                h = sha256(h).digest()
+
+            if progress_callback:
+                progress = min(int((i + batch) * 100 / work_units), 100)
+                if progress != last_progress:
+                    last_progress = progress
+                    progress_callback(progress)
+
+        _emit_progress(progress_callback, 100)
+        return base64.urlsafe_b64encode(h)
+
+
+class ScryptStrategy(TimeLockStrategy):
+    """Memory-hard scrypt strategy executed sequentially as a time-lock puzzle."""
+
+    name = ALGORITHM_SCRYPT
+
+    def __init__(self, n: int = 2**14, r: int = 8, p: int = 1, salt: bytes | None = None):
+        _validate_scrypt_params(n, r, p)
+        self.n = n
+        self.r = r
+        self.p = p
+        self.salt = salt or token_bytes(16)
+
+    def _round(self, value: bytes) -> bytes:
+        return scrypt(value, salt=self.salt, n=self.n, r=self.r, p=self.p, dklen=32)
+
+    def derive_by_time(
+        self,
+        seed: bytes,
+        delta: timedelta,
+        progress_callback: ProgressCallback = None,
+    ) -> tuple[bytes, int]:
+        duration = delta.total_seconds()
+        start = monotonic()
+        end = start + duration
+        material = seed
+        rounds = 0
+        last_progress = -1
+        _emit_progress(progress_callback, 0)
+
+        while True:
+            material = self._round(material)
+            rounds += 1
+
+            now = monotonic()
+            if now >= end:
+                break
+
+            if progress_callback:
+                progress = min(int((now - start) * 100 / duration), 99)
+                if progress != last_progress:
+                    last_progress = progress
+                    progress_callback(progress)
+
+        _emit_progress(progress_callback, 100)
+        return base64.urlsafe_b64encode(material), rounds
+
+    def derive_by_work(
+        self,
+        seed: bytes,
+        work_units: int,
+        progress_callback: ProgressCallback = None,
+    ) -> bytes:
+        _validate_work_units(work_units)
+        if work_units < 1:
+            raise ValueError("work_units must be >= 1")
+
+        material = seed
+        last_progress = -1
+        _emit_progress(progress_callback, 0)
+        for i in range(work_units):
+            material = self._round(material)
+            if progress_callback:
+                progress = min(int((i + 1) * 100 / work_units), 100)
+                if progress != last_progress:
+                    last_progress = progress
+                    progress_callback(progress)
+
+        _emit_progress(progress_callback, 100)
+        return base64.urlsafe_b64encode(material)
+
+    def extra_payload(self) -> dict:
+        return {
+            "scrypt": {
+                "n": self.n,
+                "r": self.r,
+                "p": self.p,
+                "salt": base64.urlsafe_b64encode(self.salt).decode(),
+            }
+        }
+
+
+def build_strategy(
+    algorithm: str,
+    *,
+    scrypt_n: int = 2**14,
+    scrypt_r: int = 8,
+    scrypt_p: int = 1,
+    scrypt_salt: bytes | None = None,
+) -> TimeLockStrategy:
+    """Build strategy instance for the selected algorithm."""
+    if algorithm == ALGORITHM_SHA256_CHAIN:
+        return Sha256ChainStrategy()
+    if algorithm == ALGORITHM_SCRYPT:
+        return ScryptStrategy(
+            n=scrypt_n,
+            r=scrypt_r,
+            p=scrypt_p,
+            salt=scrypt_salt,
+        )
+    raise ValueError("Unsupported algorithm. Use 'sha256-chain' or 'scrypt'.")
+
+
+def encrypt_with_strategy(
+    keyseed: bytes,
+    delta: timedelta,
+    message: bytes,
+    strategy: TimeLockStrategy,
+    progress_callback: ProgressCallback = None,
+) -> tuple[bytes, int, bytes, dict]:
+    """Time-lock encrypt using the provided strategy."""
+    key, work_units = strategy.derive_by_time(keyseed, delta, progress_callback)
+    encrypted = Fernet(key).encrypt(message)
+    return key, work_units, encrypted, strategy.extra_payload()
+
+
+def decrypt_with_strategy(
+    keyseed: bytes,
+    work_units: int,
+    encrypted: bytes,
+    strategy: TimeLockStrategy,
+    progress_callback: ProgressCallback = None,
+) -> tuple[bytes, bytes]:
+    """Reproduce the strategy key and decrypt encrypted payload."""
+    key = strategy.derive_by_work(keyseed, work_units, progress_callback)
+    decrypted = Fernet(key).decrypt(encrypted)
+    return key, decrypted
 
 
 def generate_by_time(
     seed: bytes,
     delta: timedelta,
-    progress_callback: Callable[[int], None] | None = None,
+    progress_callback: ProgressCallback = None,
 ) -> tuple[bytes, int]:
-    """Hash *seed* repeatedly for *delta* seconds and return the key + iteration count.
-
-    Args:
-        seed: Starting bytes for the hash chain.
-        delta: How long to run the hashing loop.
-        progress_callback: Optional callable receiving progress in [0, 100].
-
-    Returns:
-        A tuple of (url-safe base-64 key, number of iterations performed).
-    """
-    duration = delta.total_seconds()
-    start = monotonic()
-    end = start + duration
-
-    h = sha256(seed).digest()
-    iters = 0
-    last_progress = -1
-
-    while True:
-        # Run a batch of iterations before checking the clock.
-        for _ in range(_TICK_INTERVAL):
-            h = sha256(h).digest()
-        iters += _TICK_INTERVAL
-
-        now = monotonic()
-        if now >= end:
-            break
-
-        if progress_callback:
-            progress = min(int((now - start) * 100 / duration), 99)
-            if progress != last_progress:
-                last_progress = progress
-                progress_callback(progress)
-
-    if progress_callback:
-        progress_callback(100)
-
-    return base64.urlsafe_b64encode(h), iters
+    """Backward-compatible SHA-256 time-lock key derivation."""
+    strategy = Sha256ChainStrategy()
+    return strategy.derive_by_time(seed, delta, progress_callback)
 
 
 def generate_by_iters(
     seed: bytes,
     iters: int,
-    progress_callback: Callable[[int], None] | None = None,
+    progress_callback: ProgressCallback = None,
 ) -> bytes:
-    """Reproduce a hash-chain key by running exactly *iters* hashes.
-
-    Args:
-        seed: Starting bytes for the hash chain.
-        iters: Number of sequential SHA-256 rounds to perform.
-        progress_callback: Optional callable receiving progress in [0, 100].
-
-    Returns:
-        The url-safe base-64 encoded final hash (Fernet-compatible key).
-    """
-    h = sha256(seed).digest()
-    last_progress = -1
-
-    for i in range(0, iters, _TICK_INTERVAL):
-        batch = min(_TICK_INTERVAL, iters - i)
-        for _ in range(batch):
-            h = sha256(h).digest()
-
-        if progress_callback:
-            progress = min(int((i + batch) * 100 / iters), 100)
-            if progress != last_progress:
-                last_progress = progress
-                progress_callback(progress)
-
-    if progress_callback:
-        progress_callback(100)
-
-    return base64.urlsafe_b64encode(h)
+    """Backward-compatible SHA-256 work replay key derivation."""
+    strategy = Sha256ChainStrategy()
+    return strategy.derive_by_work(seed, iters, progress_callback)
 
 
 def encrypt(
     keyseed: bytes,
     delta: timedelta,
     message: bytes,
-    progress_callback: Callable[[int], None] | None = None,
+    progress_callback: ProgressCallback = None,
 ) -> tuple[bytes, int, bytes]:
-    """Time-lock encrypt *message* using a hash-chain key derived from *keyseed*.
-
-    Args:
-        keyseed: Seed bytes used to derive the Fernet key.
-        delta: CPU time budget for key derivation (same budget required to decrypt).
-        message: Plaintext bytes to encrypt.
-        progress_callback: Optional callable receiving progress in [0, 100].
-
-    Returns:
-        A tuple of (derived key, iteration count, Fernet ciphertext).
-    """
-    key, iterations = generate_by_time(keyseed, delta, progress_callback)
-    encrypted = Fernet(key).encrypt(message)
-    return key, iterations, encrypted
+    """Backward-compatible SHA-256 encrypt wrapper."""
+    strategy = Sha256ChainStrategy()
+    key, work_units, encrypted, _ = encrypt_with_strategy(
+        keyseed,
+        delta,
+        message,
+        strategy=strategy,
+        progress_callback=progress_callback,
+    )
+    return key, work_units, encrypted
 
 
 def decrypt(
     keyseed: bytes,
     iterations: int,
     encrypted: bytes,
-    progress_callback: Callable[[int], None] | None = None,
+    progress_callback: ProgressCallback = None,
 ) -> tuple[bytes, bytes]:
-    """Reproduce the hash-chain key and decrypt *encrypted*.
-
-    Args:
-        keyseed: Same seed used during encryption.
-        iterations: Iteration count returned by :func:`encrypt`.
-        encrypted: Fernet ciphertext produced by :func:`encrypt`.
-        progress_callback: Optional callable receiving progress in [0, 100].
-
-    Returns:
-        A tuple of (derived key, plaintext bytes).
-    """
-    key = generate_by_iters(keyseed, iterations, progress_callback)
-    decrypted = Fernet(key).decrypt(encrypted)
-    return key, decrypted
-
-
-def encrypt_scrypt(
-    keyseed: bytes,
-    message: bytes,
-    n: int = 2**14,
-    r: int = 8,
-    p: int = 1,
-    salt: bytes | None = None,
-    progress_callback: Callable[[int], None] | None = None,
-) -> tuple[bytes, bytes, bytes]:
-    """Encrypt message using an scrypt-derived key."""
-    chosen_salt = salt or token_bytes(16)
-    if progress_callback:
-        progress_callback(0)
-    key = generate_scrypt_key(keyseed, chosen_salt, n=n, r=r, p=p)
-    encrypted = Fernet(key).encrypt(message)
-    if progress_callback:
-        progress_callback(100)
-    return key, chosen_salt, encrypted
-
-
-def decrypt_scrypt(
-    keyseed: bytes,
-    encrypted: bytes,
-    salt: bytes,
-    n: int = 2**14,
-    r: int = 8,
-    p: int = 1,
-    progress_callback: Callable[[int], None] | None = None,
-) -> tuple[bytes, bytes]:
-    """Decrypt message using an scrypt-derived key."""
-    if progress_callback:
-        progress_callback(0)
-    key = generate_scrypt_key(keyseed, salt=salt, n=n, r=r, p=p)
-    decrypted = Fernet(key).decrypt(encrypted)
-    if progress_callback:
-        progress_callback(100)
-    return key, decrypted
+    """Backward-compatible SHA-256 decrypt wrapper."""
+    strategy = Sha256ChainStrategy()
+    return decrypt_with_strategy(
+        keyseed,
+        iterations,
+        encrypted,
+        strategy=strategy,
+        progress_callback=progress_callback,
+    )

--- a/puzzle.py
+++ b/puzzle.py
@@ -116,8 +116,6 @@ class Sha256ChainStrategy(TimeLockStrategy):
         progress_callback: ProgressCallback = None,
     ) -> bytes:
         _validate_work_units(work_units)
-        if work_units < 1:
-            raise ValueError("work_units must be >= 1")
 
         h = sha256(seed).digest()
         last_progress = -1
@@ -191,8 +189,6 @@ class ScryptStrategy(TimeLockStrategy):
         progress_callback: ProgressCallback = None,
     ) -> bytes:
         _validate_work_units(work_units)
-        if work_units < 1:
-            raise ValueError("work_units must be >= 1")
 
         material = seed
         last_progress = -1

--- a/puzzle.py
+++ b/puzzle.py
@@ -10,6 +10,7 @@ from typing import Callable
 
 from cryptography.fernet import Fernet
 
+ALGORITHM_SHA256 = "sha256"
 ALGORITHM_SHA256_CHAIN = "sha256-chain"
 ALGORITHM_SCRYPT = "scrypt"
 
@@ -73,7 +74,7 @@ class TimeLockStrategy(ABC):
 class Sha256ChainStrategy(TimeLockStrategy):
     """Sequential SHA-256 chain strategy."""
 
-    name = ALGORITHM_SHA256_CHAIN
+    name = ALGORITHM_SHA256
 
     def derive_by_time(
         self,
@@ -227,7 +228,7 @@ def build_strategy(
     scrypt_salt: bytes | None = None,
 ) -> TimeLockStrategy:
     """Build strategy instance for the selected algorithm."""
-    if algorithm == ALGORITHM_SHA256_CHAIN:
+    if algorithm in (ALGORITHM_SHA256, ALGORITHM_SHA256_CHAIN):
         return Sha256ChainStrategy()
     if algorithm == ALGORITHM_SCRYPT:
         return ScryptStrategy(
@@ -236,7 +237,7 @@ def build_strategy(
             p=scrypt_p,
             salt=scrypt_salt,
         )
-    raise ValueError("Unsupported algorithm. Use 'sha256-chain' or 'scrypt'.")
+    raise ValueError("Unsupported algorithm. Use 'sha256' or 'scrypt'.")
 
 
 def encrypt_with_strategy(

--- a/puzzle.py
+++ b/puzzle.py
@@ -5,11 +5,15 @@ Reference: https://asecuritysite.com/encryption/pow
 
 import base64
 from datetime import timedelta
-from hashlib import sha256
+from hashlib import scrypt, sha256
+from secrets import token_bytes
 from time import monotonic
 from typing import Callable
 
 from cryptography.fernet import Fernet
+
+ALGORITHM_SHA256_CHAIN = "sha256-chain"
+ALGORITHM_SCRYPT = "scrypt"
 
 # How often to sample wall-clock time and fire progress callbacks in the
 # tight hashing loop. Checking time() every iteration is measurably slow;
@@ -23,6 +27,23 @@ def _hash_chain(seed: bytes, count: int) -> bytes:
     for _ in range(count):
         h = sha256(h).digest()
     return h
+
+
+def _validate_scrypt_params(n: int, r: int, p: int) -> None:
+    """Validate scrypt work-factor parameters."""
+    if n < 2 or (n & (n - 1)) != 0:
+        raise ValueError("scrypt n must be a power of two and >= 2")
+    if r < 1:
+        raise ValueError("scrypt r must be >= 1")
+    if p < 1:
+        raise ValueError("scrypt p must be >= 1")
+
+
+def generate_scrypt_key(seed: bytes, salt: bytes, n: int, r: int, p: int) -> bytes:
+    """Derive a Fernet-compatible key using scrypt (memory-hard)."""
+    _validate_scrypt_params(n, r, p)
+    key = scrypt(seed, salt=salt, n=n, r=r, p=p, dklen=32)
+    return base64.urlsafe_b64encode(key)
 
 
 def generate_by_time(
@@ -146,4 +167,43 @@ def decrypt(
     """
     key = generate_by_iters(keyseed, iterations, progress_callback)
     decrypted = Fernet(key).decrypt(encrypted)
+    return key, decrypted
+
+
+def encrypt_scrypt(
+    keyseed: bytes,
+    message: bytes,
+    n: int = 2**14,
+    r: int = 8,
+    p: int = 1,
+    salt: bytes | None = None,
+    progress_callback: Callable[[int], None] | None = None,
+) -> tuple[bytes, bytes, bytes]:
+    """Encrypt message using an scrypt-derived key."""
+    chosen_salt = salt or token_bytes(16)
+    if progress_callback:
+        progress_callback(0)
+    key = generate_scrypt_key(keyseed, chosen_salt, n=n, r=r, p=p)
+    encrypted = Fernet(key).encrypt(message)
+    if progress_callback:
+        progress_callback(100)
+    return key, chosen_salt, encrypted
+
+
+def decrypt_scrypt(
+    keyseed: bytes,
+    encrypted: bytes,
+    salt: bytes,
+    n: int = 2**14,
+    r: int = 8,
+    p: int = 1,
+    progress_callback: Callable[[int], None] | None = None,
+) -> tuple[bytes, bytes]:
+    """Decrypt message using an scrypt-derived key."""
+    if progress_callback:
+        progress_callback(0)
+    key = generate_scrypt_key(keyseed, salt=salt, n=n, r=r, p=p)
+    decrypted = Fernet(key).decrypt(encrypted)
+    if progress_callback:
+        progress_callback(100)
     return key, decrypted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ passobfuscator = "main:app"
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
+    "pytest-xdist>=3.8.0",
 ]
 
 [tool.pytest.ini_options]

--- a/replit.md
+++ b/replit.md
@@ -7,7 +7,7 @@ A Python CLI tool that time-lock encrypts sensitive values (like passwords) by r
 ```
 .
 ├── main.py          # CLI entry point (typer): generate-password, encrypt, decrypt
-├── puzzle.py        # Hash-chain key derivation + Fernet encrypt/decrypt
+├── puzzle.py        # Strategy-based time-lock key derivation + Fernet encrypt/decrypt
 ├── randpass.py      # Cryptographically secure password generator (secrets module)
 ├── progress.py      # tqdm progress-bar helper with context manager support
 ├── tests/           # pytest test suite
@@ -21,7 +21,7 @@ A Python CLI tool that time-lock encrypts sensitive values (like passwords) by r
 - **Language**: Python 3.12
 - **Package management**: uv (pyproject.toml + uv.lock)
 - **CLI**: typer ≥ 0.12.0
-- **Cryptography**: cryptography library (Fernet), hashlib SHA-256, hashlib scrypt
+- **Cryptography**: cryptography library (Fernet), hashlib (SHA-256 and scrypt)
 - **Progress**: tqdm
 - **Testing**: pytest + pytest-cov
 

--- a/replit.md
+++ b/replit.md
@@ -48,6 +48,7 @@ uv run pytest tests/ -v
 
 - `randpass.py` uses `secrets` (not `random`) for cryptographic security.
 - `puzzle.py` batches SHA-256 iterations in groups of 5,000 before checking the clock, keeping progress-callback overhead negligible.
-- `puzzle.py` also supports memory-hard `scrypt`, which is more resistant to commodity GPU attacks than pure hash chains.
+- `puzzle.py` uses a strategy pattern so both `sha256-chain` and memory-hard `scrypt` act as time-lock strategies for encryption and decryption.
+- progress bars are optional in the CLI (`--show-progress`) and are disabled by default to keep stdout JSON clean.
 - `main.py` uses `None` as the seed default (not a function call evaluated at import time) to ensure each invocation gets a fresh seed.
 - `progress.py` implements the context manager protocol so callers can use `with ProgressBar() as pb:`.

--- a/replit.md
+++ b/replit.md
@@ -48,7 +48,7 @@ uv run pytest tests/ -v
 
 - `randpass.py` uses `secrets` (not `random`) for cryptographic security.
 - `puzzle.py` batches SHA-256 iterations in groups of 5,000 before checking the clock, keeping progress-callback overhead negligible.
-- `puzzle.py` uses a strategy pattern so both `sha256-chain` and memory-hard `scrypt` act as time-lock strategies for encryption and decryption.
+- `puzzle.py` uses a strategy pattern so both `sha256` and memory-hard `scrypt` act as time-lock strategies for encryption and decryption.
 - progress bars are optional in the CLI (`--show-progress`) and are disabled by default to keep stdout JSON clean.
 - `main.py` uses `None` as the seed default (not a function call evaluated at import time) to ensure each invocation gets a fresh seed.
 - `progress.py` implements the context manager protocol so callers can use `with ProgressBar() as pb:`.

--- a/replit.md
+++ b/replit.md
@@ -10,7 +10,7 @@ A Python CLI tool that time-lock encrypts sensitive values (like passwords) by r
 ├── puzzle.py        # Hash-chain key derivation + Fernet encrypt/decrypt
 ├── randpass.py      # Cryptographically secure password generator (secrets module)
 ├── progress.py      # tqdm progress-bar helper with context manager support
-├── tests/           # pytest test suite (35 tests)
+├── tests/           # pytest test suite
 ├── pyproject.toml   # Project metadata, dependencies, tool config (uv/pip)
 ├── uv.lock          # Reproducible lock file
 └── README.md
@@ -21,32 +21,33 @@ A Python CLI tool that time-lock encrypts sensitive values (like passwords) by r
 - **Language**: Python 3.12
 - **Package management**: uv (pyproject.toml + uv.lock)
 - **CLI**: typer ≥ 0.12.0
-- **Cryptography**: cryptography library (Fernet), hashlib SHA-256
+- **Cryptography**: cryptography library (Fernet), hashlib SHA-256, hashlib scrypt
 - **Progress**: tqdm
 - **Testing**: pytest + pytest-cov
 
 ## Running
 
 ```bash
-python main.py --help
-python main.py generate-password --length 16
-python main.py encrypt 'secret' --time-in-seconds 10 --output-file locked.json
-python main.py decrypt locked.json
+uv run python main.py --help
+uv run python main.py generate-password --length 16
+uv run python main.py encrypt 'secret' --time-in-seconds 10 --output-file locked.json
+uv run python main.py decrypt locked.json
 ```
 
 ## Testing
 
 ```bash
-python -m pytest tests/ -v
+uv run pytest tests/ -v
 ```
 
 ## Workflow
 
-"Start application" runs `python main.py --help` as a console workflow.
+"Start application" runs `uv run python main.py --help` as a console workflow.
 
 ## Key Design Decisions
 
 - `randpass.py` uses `secrets` (not `random`) for cryptographic security.
 - `puzzle.py` batches SHA-256 iterations in groups of 5,000 before checking the clock, keeping progress-callback overhead negligible.
+- `puzzle.py` also supports memory-hard `scrypt`, which is more resistant to commodity GPU attacks than pure hash chains.
 - `main.py` uses `None` as the seed default (not a function call evaluated at import time) to ensure each invocation gets a fresh seed.
 - `progress.py` implements the context manager protocol so callers can use `with ProgressBar() as pb:`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestEncryptCommand:
         data = _extract_json(result.output)
         assert "seed" in data
         assert "work_units" in data
-        assert data["algorithm"] == "sha256-chain"
+        assert data["algorithm"] == "sha256"
         assert "encrypted" in data
 
     def test_output_file(self, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,8 @@ class TestEncryptCommand:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "seed" in data
-        assert "iters" in data
+        assert "work_units" in data
+        assert data["algorithm"] == "sha256-chain"
         assert "encrypted" in data
 
     def test_output_file(self, tmp_path: Path) -> None:
@@ -75,7 +76,7 @@ class TestEncryptCommand:
         )
         assert result.exit_code == 0
         data = _extract_json(result.output)
-        assert data["iters"] > 0
+        assert data["work_units"] > 0
 
     def test_scrypt_stdout_output(self) -> None:
         result = runner.invoke(
@@ -85,6 +86,8 @@ class TestEncryptCommand:
                 "mypassword",
                 "--algorithm",
                 "scrypt",
+                "--time-in-seconds",
+                "1",
                 "--scrypt-n",
                 "1024",
                 "--scrypt-r",
@@ -99,10 +102,24 @@ class TestEncryptCommand:
         assert "scrypt" in data
         assert "salt" in data["scrypt"]
         assert "encrypted" in data
+        assert data["work_units"] > 0
 
     def test_invalid_algorithm_exits_with_error(self) -> None:
         result = runner.invoke(app, ["encrypt", "x", "--algorithm", "unknown"])
         assert result.exit_code != 0
+
+    def test_progress_hidden_by_default(self) -> None:
+        result = runner.invoke(app, ["encrypt", "x", "--time-in-seconds", "1"])
+        assert result.exit_code == 0
+        assert "100%|" not in result.output
+
+    def test_progress_shown_when_enabled(self) -> None:
+        result = runner.invoke(
+            app,
+            ["encrypt", "x", "--time-in-seconds", "1", "--show-progress"],
+        )
+        assert result.exit_code == 0
+        assert "100%" in result.output
 
 
 class TestDecryptCommand:
@@ -142,6 +159,8 @@ class TestDecryptCommand:
                 "gpu-resistant-secret",
                 "--algorithm",
                 "scrypt",
+                "--time-in-seconds",
+                "1",
                 "--scrypt-n",
                 "1024",
                 "--output-file",
@@ -169,3 +188,15 @@ class TestDecryptCommand:
         )
         result = runner.invoke(app, ["decrypt", str(bad_payload)])
         assert result.exit_code != 0
+
+    def test_decrypt_progress_hidden_by_default(self, tmp_path: Path) -> None:
+        enc_file = self._encrypt_to_file(tmp_path, "hello-world")
+        result = runner.invoke(app, ["decrypt", str(enc_file)])
+        assert result.exit_code == 0
+        assert "100%|" not in result.output
+
+    def test_decrypt_progress_shown_when_enabled(self, tmp_path: Path) -> None:
+        enc_file = self._encrypt_to_file(tmp_path, "hello-world")
+        result = runner.invoke(app, ["decrypt", str(enc_file), "--show-progress"])
+        assert result.exit_code == 0
+        assert "100%" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,33 @@ class TestEncryptCommand:
         data = _extract_json(result.output)
         assert data["iters"] > 0
 
+    def test_scrypt_stdout_output(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "encrypt",
+                "mypassword",
+                "--algorithm",
+                "scrypt",
+                "--scrypt-n",
+                "1024",
+                "--scrypt-r",
+                "8",
+                "--scrypt-p",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0
+        data = _extract_json(result.output)
+        assert data["algorithm"] == "scrypt"
+        assert "scrypt" in data
+        assert "salt" in data["scrypt"]
+        assert "encrypted" in data
+
+    def test_invalid_algorithm_exits_with_error(self) -> None:
+        result = runner.invoke(app, ["encrypt", "x", "--algorithm", "unknown"])
+        assert result.exit_code != 0
+
 
 class TestDecryptCommand:
     def _encrypt_to_file(self, tmp_path: Path, plaintext: str = "secret") -> Path:
@@ -104,4 +131,41 @@ class TestDecryptCommand:
 
     def test_missing_input_file_exits_with_error(self, tmp_path: Path) -> None:
         result = runner.invoke(app, ["decrypt", str(tmp_path / "nonexistent.json")])
+        assert result.exit_code != 0
+
+    def test_round_trip_with_scrypt(self, tmp_path: Path) -> None:
+        enc_file = tmp_path / "enc_scrypt.json"
+        encrypt_result = runner.invoke(
+            app,
+            [
+                "encrypt",
+                "gpu-resistant-secret",
+                "--algorithm",
+                "scrypt",
+                "--scrypt-n",
+                "1024",
+                "--output-file",
+                str(enc_file),
+            ],
+        )
+        assert encrypt_result.exit_code == 0
+
+        result = runner.invoke(app, ["decrypt", str(enc_file)])
+        assert result.exit_code == 0
+        data = _extract_json(result.output)
+        assert data["algorithm"] == "scrypt"
+        assert data["decrypted"] == "gpu-resistant-secret"
+
+    def test_decrypt_unknown_algorithm_exits(self, tmp_path: Path) -> None:
+        bad_payload = tmp_path / "bad.json"
+        bad_payload.write_text(
+            json.dumps(
+                {
+                    "algorithm": "unknown",
+                    "seed": "seed",
+                    "encrypted": "x",
+                }
+            )
+        )
+        result = runner.invoke(app, ["decrypt", str(bad_payload)])
         assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ class TestEncryptCommand:
         data = _extract_json(result.output)
         assert data["seed"] == "myseed"
 
-    def test_iters_is_positive(self) -> None:
+    def test_work_units_is_positive(self) -> None:
         result = runner.invoke(
             app,
             ["encrypt", "x", "--time-in-seconds", "1"],

--- a/tests/test_puzzle.py
+++ b/tests/test_puzzle.py
@@ -72,8 +72,12 @@ class TestGenerateByTime:
 
 class TestStrategyFactory:
     def test_build_sha256_strategy(self) -> None:
+        strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256)
+        assert strategy.name == puzzle.ALGORITHM_SHA256
+
+    def test_build_legacy_sha256_chain_alias(self) -> None:
         strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256_CHAIN)
-        assert strategy.name == puzzle.ALGORITHM_SHA256_CHAIN
+        assert strategy.name == puzzle.ALGORITHM_SHA256
 
     def test_build_scrypt_strategy(self) -> None:
         strategy = puzzle.build_strategy(
@@ -91,7 +95,7 @@ class TestStrategyFactory:
 
 class TestStrategyEncryptDecrypt:
     def test_sha256_strategy_round_trip(self) -> None:
-        strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256_CHAIN)
+        strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256)
         _, work_units, ciphertext, _ = puzzle.encrypt_with_strategy(
             SEED, timedelta(seconds=0.1), MESSAGE, strategy=strategy
         )

--- a/tests/test_puzzle.py
+++ b/tests/test_puzzle.py
@@ -97,3 +97,79 @@ class TestEncryptDecrypt:
         assert isinstance(key, bytes)
         assert isinstance(iters, int)
         assert isinstance(ciphertext, bytes)
+
+
+class TestScrypt:
+    def test_generate_scrypt_key_returns_valid_fernet_key(self) -> None:
+        key = puzzle.generate_scrypt_key(
+            b"scrypt-seed",
+            salt=b"0123456789abcdef",
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        decoded = base64.urlsafe_b64decode(key)
+        assert len(decoded) == 32
+
+    def test_generate_scrypt_key_deterministic_with_same_inputs(self) -> None:
+        key1 = puzzle.generate_scrypt_key(
+            b"seed",
+            salt=b"0123456789abcdef",
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        key2 = puzzle.generate_scrypt_key(
+            b"seed",
+            salt=b"0123456789abcdef",
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        assert key1 == key2
+
+    def test_generate_scrypt_key_changes_when_salt_changes(self) -> None:
+        key1 = puzzle.generate_scrypt_key(
+            b"seed",
+            salt=b"salt-000000000001",
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        key2 = puzzle.generate_scrypt_key(
+            b"seed",
+            salt=b"salt-000000000002",
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        assert key1 != key2
+
+    def test_encrypt_decrypt_scrypt_round_trip(self) -> None:
+        _, salt, ciphertext = puzzle.encrypt_scrypt(
+            b"scrypt-seed",
+            MESSAGE,
+            n=2**14,
+            r=8,
+            p=1,
+            salt=b"0123456789abcdef",
+        )
+        _, decrypted = puzzle.decrypt_scrypt(
+            b"scrypt-seed",
+            ciphertext,
+            salt=salt,
+            n=2**14,
+            r=8,
+            p=1,
+        )
+        assert decrypted == MESSAGE
+
+    def test_encrypt_scrypt_invalid_n_raises(self) -> None:
+        with pytest.raises(ValueError, match="power of two"):
+            puzzle.encrypt_scrypt(
+                b"scrypt-seed",
+                MESSAGE,
+                n=1000,
+                r=8,
+                p=1,
+            )

--- a/tests/test_puzzle.py
+++ b/tests/test_puzzle.py
@@ -70,6 +70,76 @@ class TestGenerateByTime:
         assert progress_values[-1] == 100
 
 
+class TestStrategyFactory:
+    def test_build_sha256_strategy(self) -> None:
+        strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256_CHAIN)
+        assert strategy.name == puzzle.ALGORITHM_SHA256_CHAIN
+
+    def test_build_scrypt_strategy(self) -> None:
+        strategy = puzzle.build_strategy(
+            puzzle.ALGORITHM_SCRYPT,
+            scrypt_n=2**10,
+            scrypt_r=8,
+            scrypt_p=1,
+        )
+        assert strategy.name == puzzle.ALGORITHM_SCRYPT
+
+    def test_build_unknown_strategy_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported algorithm"):
+            puzzle.build_strategy("unknown")
+
+
+class TestStrategyEncryptDecrypt:
+    def test_sha256_strategy_round_trip(self) -> None:
+        strategy = puzzle.build_strategy(puzzle.ALGORITHM_SHA256_CHAIN)
+        _, work_units, ciphertext, _ = puzzle.encrypt_with_strategy(
+            SEED, timedelta(seconds=0.1), MESSAGE, strategy=strategy
+        )
+        _, decrypted = puzzle.decrypt_with_strategy(SEED, work_units, ciphertext, strategy)
+        assert decrypted == MESSAGE
+
+    def test_scrypt_strategy_time_lock_round_trip(self) -> None:
+        strategy = puzzle.build_strategy(
+            puzzle.ALGORITHM_SCRYPT,
+            scrypt_n=2**10,
+            scrypt_r=8,
+            scrypt_p=1,
+            scrypt_salt=b"0123456789abcdef",
+        )
+        _, work_units, ciphertext, payload = puzzle.encrypt_with_strategy(
+            SEED, timedelta(seconds=0.1), MESSAGE, strategy=strategy
+        )
+        assert work_units > 0
+        assert payload["scrypt"]["salt"]
+        replay_strategy = puzzle.build_strategy(
+            puzzle.ALGORITHM_SCRYPT,
+            scrypt_n=2**10,
+            scrypt_r=8,
+            scrypt_p=1,
+            scrypt_salt=b"0123456789abcdef",
+        )
+        _, decrypted = puzzle.decrypt_with_strategy(
+            SEED, work_units, ciphertext, replay_strategy
+        )
+        assert decrypted == MESSAGE
+
+    def test_scrypt_strategy_emits_progress(self) -> None:
+        progress_values: list[int] = []
+        strategy = puzzle.build_strategy(
+            puzzle.ALGORITHM_SCRYPT,
+            scrypt_n=2**10,
+            scrypt_r=8,
+            scrypt_p=1,
+            scrypt_salt=b"0123456789abcdef",
+        )
+        _, work_units = strategy.derive_by_time(
+            SEED, timedelta(seconds=0.1), progress_callback=progress_values.append
+        )
+        assert work_units > 0
+        assert progress_values[0] == 0
+        assert progress_values[-1] == 100
+
+
 class TestEncryptDecrypt:
     def test_round_trip(self) -> None:
         _, iters, ciphertext = puzzle.encrypt(SEED, timedelta(seconds=0.1), MESSAGE)
@@ -100,76 +170,45 @@ class TestEncryptDecrypt:
 
 
 class TestScrypt:
-    def test_generate_scrypt_key_returns_valid_fernet_key(self) -> None:
-        key = puzzle.generate_scrypt_key(
-            b"scrypt-seed",
-            salt=b"0123456789abcdef",
-            n=2**14,
+    def test_scrypt_strategy_derives_valid_fernet_key(self) -> None:
+        strategy = puzzle.ScryptStrategy(
+            n=2**10,
             r=8,
             p=1,
+            salt=b"0123456789abcdef",
         )
+        key = strategy.derive_by_work(b"scrypt-seed", work_units=2)
         decoded = base64.urlsafe_b64decode(key)
         assert len(decoded) == 32
 
-    def test_generate_scrypt_key_deterministic_with_same_inputs(self) -> None:
-        key1 = puzzle.generate_scrypt_key(
-            b"seed",
-            salt=b"0123456789abcdef",
-            n=2**14,
+    def test_scrypt_strategy_is_deterministic_with_same_inputs(self) -> None:
+        strategy = puzzle.ScryptStrategy(
+            n=2**10,
             r=8,
             p=1,
-        )
-        key2 = puzzle.generate_scrypt_key(
-            b"seed",
             salt=b"0123456789abcdef",
-            n=2**14,
-            r=8,
-            p=1,
         )
+        key1 = strategy.derive_by_work(b"seed", work_units=3)
+        key2 = strategy.derive_by_work(b"seed", work_units=3)
         assert key1 == key2
 
-    def test_generate_scrypt_key_changes_when_salt_changes(self) -> None:
-        key1 = puzzle.generate_scrypt_key(
-            b"seed",
+    def test_scrypt_strategy_key_changes_when_salt_changes(self) -> None:
+        strategy1 = puzzle.ScryptStrategy(
+            n=2**10,
+            r=8,
+            p=1,
             salt=b"salt-000000000001",
-            n=2**14,
+        )
+        strategy2 = puzzle.ScryptStrategy(
+            n=2**10,
             r=8,
             p=1,
-        )
-        key2 = puzzle.generate_scrypt_key(
-            b"seed",
             salt=b"salt-000000000002",
-            n=2**14,
-            r=8,
-            p=1,
         )
+        key1 = strategy1.derive_by_work(b"seed", work_units=2)
+        key2 = strategy2.derive_by_work(b"seed", work_units=2)
         assert key1 != key2
 
-    def test_encrypt_decrypt_scrypt_round_trip(self) -> None:
-        _, salt, ciphertext = puzzle.encrypt_scrypt(
-            b"scrypt-seed",
-            MESSAGE,
-            n=2**14,
-            r=8,
-            p=1,
-            salt=b"0123456789abcdef",
-        )
-        _, decrypted = puzzle.decrypt_scrypt(
-            b"scrypt-seed",
-            ciphertext,
-            salt=salt,
-            n=2**14,
-            r=8,
-            p=1,
-        )
-        assert decrypted == MESSAGE
-
-    def test_encrypt_scrypt_invalid_n_raises(self) -> None:
+    def test_scrypt_strategy_invalid_n_raises(self) -> None:
         with pytest.raises(ValueError, match="power of two"):
-            puzzle.encrypt_scrypt(
-                b"scrypt-seed",
-                MESSAGE,
-                n=1000,
-                r=8,
-                p=1,
-            )
+            puzzle.ScryptStrategy(n=1000, r=8, p=1, salt=b"0123456789abcdef")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -266,6 +270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +331,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -331,6 +345,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]
@@ -388,6 +403,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refactor key derivation to a strategy pattern so encryption/decryption both use interchangeable time-lock strategies
- implement `sha256` and `scrypt` as full time-lock strategies (derive-by-time + replay-by-work)
- add CLI `--show-progress` toggle (off by default) for both `encrypt` and `decrypt`
- keep backward compatibility for decrypting old payloads (`iters` and legacy algorithm value `sha256-chain`) while writing new payloads with `work_units` and `sha256`
- perform cleanup pass for code quality and naming consistency without changing behavior
- validate docs/tests alignment with the project purpose

## Details
- `puzzle.py`
  - introduces abstract `TimeLockStrategy` with `derive_by_time` and `derive_by_work`
  - adds `Sha256ChainStrategy` and `ScryptStrategy`
  - adds strategy factory `build_strategy(...)`
  - adds `encrypt_with_strategy(...)` / `decrypt_with_strategy(...)`
  - renames canonical SHA algorithm id to `sha256` and keeps legacy alias constant `sha256-chain` for backward compatibility
  - ensures both strategies accept optional progress callback and emit progress from 0 to 100
  - cleanup: removed duplicate `work_units` checks and tightened validation flow
- `main.py`
  - uses strategy factory for algorithm selection
  - uses `time_in_seconds` for both algorithms as requested
  - stores strategy replay count as `work_units` in output JSON
  - keeps decrypt compatibility for old files by reading `work_units` or fallback `iters`
  - normalizes legacy `sha256-chain` payloads to canonical `sha256` output
  - adds `--show-progress` option for `encrypt` and `decrypt` (default false)
  - cleanup: simplified legacy normalization and work-unit extraction logic
- tests
  - expanded strategy tests in `tests/test_puzzle.py`
  - updated CLI tests in `tests/test_cli.py` for `work_units`, scrypt time-lock flow, progress visibility toggling, and `sha256` naming
  - cleanup: renamed one CLI test for clarity (`test_work_units_is_positive`)
- docs/config
  - updated `README.md` and `replit.md` to reflect strategy/time-lock model, optional progress, and `sha256` naming
  - `.replit` remains uv-based (`uv run python main.py --help`)

## Validation
- `uv run pytest tests -v`
- `uv run python main.py encrypt 'quality-check' --algorithm sha256 --time-in-seconds 1 --output-file /tmp/q_sha.json`
- `uv run python main.py decrypt /tmp/q_sha.json`
- `uv run python main.py encrypt 'quality-check-scrypt' --algorithm scrypt --time-in-seconds 1 --scrypt-n 1024 --output-file /tmp/q_scrypt.json`
- `uv run python main.py decrypt /tmp/q_scrypt.json`
- legacy compatibility check: decrypt payload with `algorithm: sha256-chain` still succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45f3099d-1924-4ce6-9e97-2a007d9d166a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45f3099d-1924-4ce6-9e97-2a007d9d166a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

